### PR TITLE
add closes/resolves to default PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/default.md
+++ b/.github/PULL_REQUEST_TEMPLATE/default.md
@@ -19,6 +19,7 @@
 <!-- Any notable link here that can aid in the exploration review of the PR, as well as context -->
 
 [ISSUE-ISSUEID](https://github.com/GetAutomaApp/AutomaInfraCore/issues/ISSUEID)
+closes/resolves #ISSUEID
 
 # Testing
 


### PR DESCRIPTION
Adds a closes/resolves to specific issues when creating a PR. This makes it super easy to find&replace and ensuring respective issues are closed after mergngi.